### PR TITLE
Add Vercel deploy config for frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@
 # ============================================
 
 # Backend API URL
+#   Local dev:   http://localhost:3001/api/v1
+#   ngrok:       https://<subdomain>.ngrok-free.app/api/v1
+#   Production:  https://<your-api-host>/api/v1
 VITE_API_URL=http://localhost:3001/api/v1
 
 # Supabase (for auth on client-side)

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,10 @@
+thaifruit-api/
+supabase/
+*.md
+!index.html
+node_modules/
+dist/
+.env
+.env.local
+.claude/
+.mcp.json

--- a/thaifruit-api/.env.example
+++ b/thaifruit-api/.env.example
@@ -13,7 +13,11 @@ SUPABASE_DB_PASSWORD=your-database-password
 
 # Server
 PORT=3001
-CORS_ORIGIN=http://localhost:5176
+# Comma-separated list of allowed origins. Include every frontend URL that calls this API.
+#   Local dev:       http://localhost:5173
+#   Vercel preview:  https://<project>-<hash>.vercel.app
+#   Vercel prod:     https://<project>.vercel.app
+CORS_ORIGIN=http://localhost:5173,http://localhost:5176
 
 # Supabase Storage bucket name (create in Dashboard → Storage)
 STORAGE_BUCKET=product-images

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':(exclude)thaifruit-api'"
+}


### PR DESCRIPTION
- vercel.json: Vite framework preset, SPA rewrites, ignore backend-only commits
- .vercelignore: exclude backend + supabase dirs from frontend build context
- .env.example (frontend): document ngrok and production VITE_API_URL forms
- thaifruit-api/.env.example: show comma-separated CORS_ORIGIN for multiple frontends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API endpoint examples for local development, ngrok, and production environments.

* **Chores**
  * Updated deployment configuration with build and routing settings.
  * Expanded CORS origin settings to support multiple frontend URLs.
  * Added deployment ignore rules to exclude unnecessary files from the deployment package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->