### PR TITLE
Render Blueprint + trust-proxy for production deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,29 @@ thaifruit-api/
 - Backend uses ESM (`"type": "module"`)
 - All credentials in `.env` files, never committed
 
+## Deployment
+
+Two deployable apps, two cloud providers. Both auto-deploy from GitHub.
+
+| Tier | Service | URL pattern | Source |
+|------|---------|-------------|--------|
+| Frontend | Vercel | `https://thaifruit.vercel.app` | `main` (whole repo, Vite build) |
+| Backend | Render | `https://thaifruit-api.onrender.com` | `main` (`thaifruit-api/` rootDir) |
+| Database / Auth / Storage | Supabase Cloud | `https://qtrvjfkimwtvtlwsiadq.supabase.co` | managed |
+
+**Render Blueprint** lives at `render.yaml` at the repo root. To re-create the service from scratch (e.g., on a fresh Render account): https://dashboard.render.com/blueprints → **New Blueprint Instance** → point at this repo. Render auto-fills every setting; you'll be prompted once for the three Supabase secrets (which `sync: false` keeps out of the file).
+
+**Where each env var lives**:
+- **Vercel project settings** → `VITE_API_URL` (the only one)
+- **Render service env vars** → `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `SUPABASE_ANON_KEY` (secrets), plus `STORAGE_BUCKET`, `CORS_ORIGIN`, `NODE_ENV` (declared in `render.yaml`)
+- **Local `.env`** files → only for `npm run dev`. Never committed.
+
+**Updating CORS allowlist**: edit `CORS_ORIGIN` in the Render dashboard; restart isn't needed (Express picks up the value on the next request? No — actually env vars are read at boot. Render auto-restarts when you save an env var change.).
+
+**Free tier sleep**: the Render free plan sleeps after 15 minutes idle. First request after sleep takes ~30 s to wake. Upgrade to the Starter plan ($7/mo) for always-on.
+
+**Trust-proxy**: `app.set('trust proxy', 1)` is set in `src/app.js` so `express-rate-limit` and `req.ip` see the real client IP from `X-Forwarded-For` (Render fronts the service with a load balancer).
+
 ## Known Lint Errors (pre-existing, not blocking)
 
 - `fruit-marketplace_1.jsx` — unused `stores` variable (legacy reference file)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,39 @@
+# Render Blueprint — declares the ThaiFruit API as a Web Service.
+# Apply at https://dashboard.render.com/blueprints → "New Blueprint Instance"
+# and point it at this repo. Render will auto-fill every setting below;
+# you'll be prompted for the four `sync: false` secrets once.
+#
+# Reference: https://render.com/docs/blueprint-spec
+
+services:
+  - type: web
+    name: thaifruit-api
+    runtime: node
+    region: singapore        # Closest to TH users. Other options: oregon, frankfurt, ohio.
+    plan: free               # Sleeps after 15 min idle. Upgrade to "starter" ($7/mo) for always-on.
+    rootDir: thaifruit-api   # Render runs npm install / npm start from this folder.
+    buildCommand: npm install
+    startCommand: npm start  # Resolves to `node src/server.js` per package.json.
+    healthCheckPath: /api/v1/health
+    autoDeploy: true         # Re-deploy on every push to the tracked branch.
+    branch: main             # Change to deploy/render-setup or feat/* while iterating.
+
+    envVars:
+      # Non-secret values can ship in the blueprint:
+      - key: NODE_ENV
+        value: production
+      - key: STORAGE_BUCKET
+        value: product-images
+      # Set this to the comma-separated list of frontend origins allowed by CORS.
+      # Render's UI lets you edit this without re-applying the blueprint.
+      - key: CORS_ORIGIN
+        value: "https://thaifruit.vercel.app,https://thai-fruit.vercel.app"
+
+      # Secrets — Render will prompt for the value when the blueprint is applied.
+      # `sync: false` means: never overwrite this from the blueprint; treat the dashboard as source of truth.
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_SERVICE_KEY
+        sync: false
+      - key: SUPABASE_ANON_KEY
+        sync: false

--- a/thaifruit-api/src/app.js
+++ b/thaifruit-api/src/app.js
@@ -15,6 +15,10 @@ import { mountDocs } from './openapi/index.js';
 export function createApp() {
   const app = express();
 
+  // Behind Render / Vercel / nginx, the real client IP is in X-Forwarded-For.
+  // Trust one hop so express-rate-limit and req.ip get the right address.
+  app.set('trust proxy', 1);
+
   // Security
   app.use(helmet());
   app.use(cors({ origin: env.corsOrigin, credentials: true }));


### PR DESCRIPTION
> Stacked on top of #4 (which is stacked on #3). Merge those first; this rebases automatically.

## Summary
- **`render.yaml`** at the repo root declares the API as a Render Web Service (Singapore region, free plan, autoDeploy from main, healthCheck on `/api/v1/health`). Non-secret env vars ship in the file; the three Supabase secrets are \`sync: false\` so they only live in Render's encrypted store.
- **\`app.set('trust proxy', 1)\`** in \`src/app.js\` so \`express-rate-limit\` and \`req.ip\` see the real client IP from \`X-Forwarded-For\` instead of the load-balancer IP (which would defeat rate limiting).
- **Deployment section** added to CLAUDE.md describing the Vercel + Render + Supabase split and where each env var lives.

## Test plan
- [ ] \`npm test\` (in \`thaifruit-api/\`) → still 26/26 passing after trust-proxy change
- [ ] After merge to main, Render auto-redeploys; \`curl https://thaifruit-api.onrender.com/api/v1/categories\` returns camelCase
- [ ] \`https://thaifruit-api.onrender.com/api/v1/docs\` renders Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)